### PR TITLE
Fix dead characters tile occupation

### DIFF
--- a/packages/front/src/stages/battle/battleState/battle-action-middleware.ts
+++ b/packages/front/src/stages/battle/battleState/battle-action-middleware.ts
@@ -5,10 +5,10 @@ import { SpellActionLaunchAction } from '../spellAction/spell-action-actions';
 import { BattleStateSpellPrepareAction } from './battle-state-actions';
 
 type Dependencies<S> = SpellEngineDependencies<S> & {
-    getSpellEngineFromType?: (spellType: SpellType, api: MiddlewareAPI) => SpellEngine;
+    getSpellEngineFromType?: (spellType: SpellType, api: MiddlewareAPI, deps: SpellEngineDependencies<S>) => SpellEngine;
 };
 
-const defaultGetSpellEngineFromType = <S>(spellType: SpellType, api: MiddlewareAPI, deps: SpellEngineDependencies<S>) => {
+const defaultGetSpellEngineFromType: Dependencies<any>[ 'getSpellEngineFromType' ] = (spellType, api, deps) => {
     const spellEngineCreator = spellEngineMap[ spellType ];
 
     return spellEngineCreator(deps)(api);

--- a/packages/front/src/stages/battle/battleState/battle-action.test.ts
+++ b/packages/front/src/stages/battle/battleState/battle-action.test.ts
@@ -27,7 +27,7 @@ describe('# battle-action', () => {
 
         const middleware = battleActionMiddleware({
             extractState: () => initialState,
-            extractFutureCharacterPositionList: () => [ futureCharacter.position ],
+            extractFutureAliveCharacterPositionList: () => [ futureCharacter.position ],
             extractFutureCharacter: () => futureCharacter,
             extractFutureSpell: () => futureSpell,
             getSpellEngineFromType: () => async () => { },

--- a/packages/front/src/stages/battle/engine/spellEngine/simpleAttack/spell-engine-simpleAttack.ts
+++ b/packages/front/src/stages/battle/engine/spellEngine/simpleAttack/spell-engine-simpleAttack.ts
@@ -17,7 +17,7 @@ export const spellEngineSimpleAttack: SpellEngineCreator = ({
     extractState,
     extractFutureSpell,
     extractFutureCharacter,
-    extractFutureCharacterPositionList
+    extractFutureAliveCharacterPositionList
 }) => api => {
 
     const onTileHover = (tilePos: Position, tileType: TileType) => {
@@ -86,7 +86,7 @@ export const spellEngineSimpleAttack: SpellEngineCreator = ({
 
             const futureCharacterPosition = extractFutureCharacter(api.getState)!.position;
             const spellArea = extractFutureSpell(api.getState)!.feature.area;
-            const charactersPos = extractFutureCharacterPositionList(api.getState)
+            const charactersPos = extractFutureAliveCharacterPositionList(api.getState)
                 .filter(p => !equals(futureCharacterPosition)(p));
 
             const tiledManager = TiledManager(tiledSchema!);

--- a/packages/front/src/stages/battle/engine/spellEngine/spell-engine.ts
+++ b/packages/front/src/stages/battle/engine/spellEngine/spell-engine.ts
@@ -8,14 +8,14 @@ import { spellEngineSimpleAttack } from './simpleAttack/spell-engine-simpleAttac
 
 export type SpellEngineDependencies<S> = {
     extractState: (getState: () => S) => BattleActionState;
-    extractFutureCharacterPositionList: (getState: () => S) => Position[];
+    extractFutureAliveCharacterPositionList: (getState: () => S) => Position[];
     extractFutureCharacter: (getState: () => S) => Character<'future'> | undefined;
     extractFutureSpell: (getState: () => S) => Spell<'future'> | undefined;
 };
 
 export type SpellEngine = (action: AnyAction) => Promise<void>;
 
-export type SpellEngineCreator = <S>(deps: SpellEngineDependencies<S>) => (api: MiddlewareAPI) => SpellEngine;
+export type SpellEngineCreator<D = {}> = <S>(deps: SpellEngineDependencies<S> & D) => (api: MiddlewareAPI) => SpellEngine;
 
 export const spellEngineMap: {
     readonly [ K in SpellType ]: SpellEngineCreator;

--- a/packages/front/src/ui/reducers/battle-reducers/battle-middleware-list.ts
+++ b/packages/front/src/ui/reducers/battle-reducers/battle-middleware-list.ts
@@ -2,6 +2,7 @@ import { Middleware } from '@reduxjs/toolkit';
 import { GameState } from '../../../game-state';
 import { battleActionMiddleware } from '../../../stages/battle/battleState/battle-action-middleware';
 import { cycleMiddleware } from '../../../stages/battle/cycle/cycle-middleware';
+import { characterIsAlive } from '../../../stages/battle/entities/character/Character';
 import { snapshotMiddleware } from '../../../stages/battle/snapshot/snapshot-middleware';
 import { spellActionMiddleware } from '../../../stages/battle/spellAction/spell-action-middleware';
 
@@ -16,7 +17,9 @@ const extractFutureCharacter = (getState: () => GameState) => {
 export const getBattleMiddlewareList: () => readonly Middleware[] = () => [
     battleActionMiddleware<GameState>({
         extractState: getState => getState().battle.battleActionState,
-        extractFutureCharacterPositionList: getState => getState().battle.snapshotState.battleDataFuture.characters.map(c => c.position),
+        extractFutureAliveCharacterPositionList: getState => getState().battle.snapshotState.battleDataFuture.characters
+            .filter(characterIsAlive)
+            .map(c => c.position),
         extractFutureCharacter,
         extractFutureSpell: getState => {
             const { snapshotState, battleActionState } = getState().battle;


### PR DESCRIPTION
Also improve & clean spell-engine-move tests,
but there is no test for the fixed issue since it's located on `battle-middleware-list.ts`.

fix #24 