### PR TITLE
Fix global turn inconsistency

### DIFF
--- a/packages/back/src/battle/run/cycle/turn/GlobalTurn.ts
+++ b/packages/back/src/battle/run/cycle/turn/GlobalTurn.ts
@@ -57,7 +57,7 @@ export const GlobalTurn = (
             onGlobalTurnEnd(currentTurn.endTime);
         }
         else {
-            const getCurrentCharacter = () => getCharacters()[ order[ nextCharacterIndex ] ];
+            const getCurrentCharacter = () => getCharacters()[order[nextCharacterIndex]];
 
             if (characterIsAlive(getCurrentCharacter())) {
                 console.log(`Wait ${TURN_DELAY}ms`);
@@ -77,7 +77,7 @@ export const GlobalTurn = (
         return {
             id,
             startTime,
-            order: [ ...order ],
+            order: [...order],
             currentTurn: currentTurn.toSnapshot()
         };
     };
@@ -86,8 +86,13 @@ export const GlobalTurn = (
         currentTurn.clearTimedActions();
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    setCurrentTurn(Turn(turnId, startTime, () => getCharacters()[ order[0] ], () => null, onTurnEnd));
+    const firstAliveCharacterId = order.find(id => characterIsAlive(getCharacters()[id]));
+
+    if (firstAliveCharacterId) {
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        setCurrentTurn(Turn(turnId, startTime, () => getCharacters()[firstAliveCharacterId], () => null, onTurnEnd));
+    }
 
     const this_: GlobalTurn = {
         id,

--- a/packages/back/src/battle/run/cycle/turn/Turn.ts
+++ b/packages/back/src/battle/run/cycle/turn/Turn.ts
@@ -72,7 +72,18 @@ export const Turn = (
     };
 
     const start = () => {
-        console.log('TURN-START', id, `${this_.turnDuration}ms`, getCharacter().playerId);
+
+        console.log();
+        console.log('--- TURN-START ---');
+        console.table({
+            turnId: id,
+            duration: this_.turnDuration,
+            playerId: getCharacter().playerId,
+            characterId: getCharacter().id
+        });
+        console.log('--- ---------- ---');
+        console.log();
+
         lastCallback = 'start';
         onTurnStart();
         return refreshTimedActions();


### PR DESCRIPTION
The issue was that backend global turn launched its first turn with the first character, whithout checking if he's alive.
:shipit:

(this PR also improves turn start logs)

fix #92 